### PR TITLE
Add Google Colab links to Lessons 1, 2, and 3

### DIFF
--- a/content/Week_1/Lesson_01.md
+++ b/content/Week_1/Lesson_01.md
@@ -11,6 +11,8 @@ In our 100 Days of Machine Learning challenge, Python will be our go-to programm
 
 For your coding environment, as long as you have a Google account, the best choice is likely Colab, accessible at [Google Colab](https://colab.research.google.com/). Colab is a free, cloud-based version of Jupyter Notebook. It allows you to write and execute Python code through your browser, without any setup required. Colab also provides free access to computing resources, including GPUs, which can be beneficial for some of the more computationally heavy machine learning tasks.
 
+**This notebook is available for you to follow along in Colab:** [Link to Colab notebook](https://colab.research.google.com/drive/1FOfXVclC2qMBrDKnP3rAg6DYYUqUYVrh?usp=sharing)
+
 Working locally is an option, but if you don't have a CPU, you probably want to get acquainted with Colab anyway for the later challenges.
 
 **Notebooks and Cells**

--- a/content/Week_1/Lesson_02.md
+++ b/content/Week_1/Lesson_02.md
@@ -2,9 +2,9 @@
 
 Welcome back to our journey through Python and its applications in machine learning! In our previous session, we laid the foundation by exploring Python's syntax, variables, and basic arithmetic operators. Today, we're going to delve deeper into Python's diverse world of data types, and we will also introduce logical and comparison operators. These elements are not only fundamental to programming in Python but are also crucial in performing calculations and making decisions in code - skills that are essential for data analysis and machine learning. By the end of this lesson, you'll have a stronger grasp of how to manipulate different types of data and how to apply logical reasoning in your programming.
 
-## More about Data Types
+**This notebook is available for you to follow along in Colab:** [Link to Colab notebook](https://colab.research.google.com/drive/1Nl3JQRaYy-P3grWSl2ER6mrEm36DOp4h?usp=sharing)
 
-**asdf?**
+## More about Data Types
 
 - **Boolean (`bool`)**: This data type is used to represent the truth values, True and False. It is often the result of comparisons or logical operations.
   

--- a/content/Week_1/Lesson_03.md
+++ b/content/Week_1/Lesson_03.md
@@ -2,6 +2,8 @@
 
 Loops are fundamental structures in programming that allow us to execute a block of code repeatedly, under certain conditions. They are essential for automating repetitive tasks, processing collections of data, and building the backbone of algorithms. Understanding loops and how to control them is crucial for writing efficient and effective code.
 
+**This notebook is available for you to follow along in Colab:** [Link to Colab notebook](https://colab.research.google.com/drive/13h2TzSIfosqVcgljj7ps2zS7Bu8HH8O1?usp=sharing)
+
 ## Why Loop?
 
 Loops are necessary for efficient programming as they enable us to avoid repetitive code, making our scripts shorter and more readable. They are particularly valuable when dealing with large datasets or when a task needs to be repeated multiple times under certain conditions. Effective use of loops leads to cleaner, more organized, and more maintainable code.


### PR DESCRIPTION
Making colab notebooks available in parallel with the jupyter-book pages. The link to the notebook is one of the first lines under the heading.